### PR TITLE
Update accesskit to 0.24.0 and accesskit_consumer to 0.34.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,13 +9,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
 
 [[package]]
+name = "accesskit"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5351dcebb14b579ccab05f288596b2ae097005be7ee50a7c3d4ca9d0d5a66f6a"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "accesskit_consumer"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec27574c1baeb7747c802a194566b46b602461e81dc4957949580ea8da695038"
 dependencies = [
- "accesskit",
- "hashbrown",
+ "accesskit 0.21.1",
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a191faf9cb278127e253ba80af4c588527b7b9d824c58220aca00bb162a5a460"
+dependencies = [
+ "accesskit 0.24.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -96,7 +115,7 @@ name = "egui"
 version = "0.33.3"
 source = "git+https://github.com/emilk/egui?branch=main#fd257b2e95972f2bfe08cbde710f248076a08ee6"
 dependencies = [
- "accesskit",
+ "accesskit 0.21.1",
  "ahash",
  "bitflags",
  "emath",
@@ -155,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "font-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,14 +194,23 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.4",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
 name = "integration_example"
 version = "0.1.0"
 dependencies = [
- "accesskit",
+ "accesskit 0.21.1",
  "egui",
  "kittest 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot",
@@ -186,8 +220,8 @@ dependencies = [
 name = "kittest"
 version = "0.3.0"
 dependencies = [
- "accesskit",
- "accesskit_consumer",
+ "accesskit 0.24.0",
+ "accesskit_consumer 0.34.0",
 ]
 
 [[package]]
@@ -196,8 +230,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fd6dd2cce251a360101038acb9334e3a50cd38cd02fefddbf28aa975f043c8"
 dependencies = [
- "accesskit",
- "accesskit_consumer",
+ "accesskit 0.21.1",
+ "accesskit_consumer 0.30.0",
  "parking_lot",
 ]
 
@@ -389,6 +423,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "uuid"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 
 [[package]]
 name = "vello_common"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,17 +26,20 @@ checksum = "e25ae84c0260bdf5df07796d7cc4882460de26a2b406ec0e6c42461a723b271b"
 
 [[package]]
 name = "accesskit"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0690ad6e6f9597b8439bd3c95e8c6df5cd043afd950c6d68f3b37df641e27c"
+checksum = "5351dcebb14b579ccab05f288596b2ae097005be7ee50a7c3d4ca9d0d5a66f6a"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec27574c1baeb7747c802a194566b46b602461e81dc4957949580ea8da695038"
+checksum = "a191faf9cb278127e253ba80af4c588527b7b9d824c58220aca00bb162a5a460"
 dependencies = [
- "accesskit 0.21.0",
+ "accesskit 0.24.0",
  "hashbrown",
 ]
 
@@ -120,15 +123,15 @@ source = "git+https://github.com/emilk/egui?branch=main#f0abce9bb8591466ce01f741
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash",
 ]
@@ -137,7 +140,7 @@ dependencies = [
 name = "kittest"
 version = "0.3.0"
 dependencies = [
- "accesskit 0.21.0",
+ "accesskit 0.24.0",
  "accesskit_consumer",
  "egui",
  "parking_lot",
@@ -276,6 +279,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ default = []
 
 
 [dependencies]
-accesskit_consumer = "0.30.0"
-accesskit = "0.21.0"
+accesskit_consumer = "0.34.0"
+accesskit = "0.24.0"
 parking_lot = "0.12"
 
 [dev-dependencies]


### PR DESCRIPTION
this patch updates our deps to [accesskit 0.24.0](https://docs.rs/accesskit/0.24.0/accesskit/) (was [0.21.0](https://docs.rs/accesskit/0.21.0/accesskit/)) and [accesskit_consumer 0.34.0](https://docs.rs/accesskit_consumer/0.34.0/accesskit_consumer/) (was [0.30.0](https://docs.rs/accesskit_consumer/0.30.0/accesskit_consumer/)), allowing egui to be used in apps that use accessibility subtrees (AccessKit/accesskit#655).

<!--
* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* Do NOT open PR:s from your `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it passes CI.
* When you have addressed a PR comment, mark it as resolved.

Please be patient!
-->