### PR TITLE
Update accesskit to 0.24.0 and accesskit_consumer to 0.34.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,17 +26,20 @@ checksum = "e25ae84c0260bdf5df07796d7cc4882460de26a2b406ec0e6c42461a723b271b"
 
 [[package]]
 name = "accesskit"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0690ad6e6f9597b8439bd3c95e8c6df5cd043afd950c6d68f3b37df641e27c"
+checksum = "5351dcebb14b579ccab05f288596b2ae097005be7ee50a7c3d4ca9d0d5a66f6a"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec27574c1baeb7747c802a194566b46b602461e81dc4957949580ea8da695038"
+checksum = "a191faf9cb278127e253ba80af4c588527b7b9d824c58220aca00bb162a5a460"
 dependencies = [
- "accesskit 0.21.0",
+ "accesskit 0.24.0",
  "hashbrown",
 ]
 
@@ -120,15 +123,15 @@ source = "git+https://github.com/emilk/egui?branch=main#f0abce9bb8591466ce01f741
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash",
 ]
@@ -137,7 +140,7 @@ dependencies = [
 name = "kittest"
 version = "0.3.0"
 dependencies = [
- "accesskit 0.21.0",
+ "accesskit 0.24.0",
  "accesskit_consumer",
  "egui",
  "parking_lot",
@@ -276,6 +279,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "uuid"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ default = []
 
 
 [dependencies]
-accesskit_consumer = "0.30.0"
-accesskit = "0.21.0"
+accesskit_consumer = "0.34.0"
+accesskit = "0.24.0"
 parking_lot = "0.12"
 
 [dev-dependencies]


### PR DESCRIPTION
Update accesskit to 0.24.0 (was 0.21.0) and accesskit_consumer to 0.34.0 (was 0.30.0).

The only breaking change in accesskit 0.24.0 vs 0.23.0 is a MSRV bump to 1.85, which kittest already requires. The 0.23.0 release added multiple tree support (`TreeId`, `target_tree`/`target_node` split in `ActionRequest`), and 0.22.0 had various type changes (Color struct, font size/weight as f32, etc.).

No source code changes are needed in kittest since it passes `TreeUpdate` through without inspecting the changed fields.

This supersedes #18 by going directly to 0.24.0.